### PR TITLE
fix(Request#then): match native Promise#then

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class Request {
 	}
 
 	then(resolver, rejector) {
-		return this._request().then(resolver).catch(rejector);
+		return this._request().then(resolver, rejector);
 	}
 
 	catch(rejector) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**:
Make Request#then match the native Promise#then call: `.then(resolve, reject)` is not equal to `.then(resolve).catch(reject)`.


**Semantic versioning classification:**  
- This PR changes the library's code in some way
  - SEMVER patch (bug fix)